### PR TITLE
Fixed extraction error on Windows

### DIFF
--- a/src/luarocks/build/tree-sitter-cli.lua
+++ b/src/luarocks/build/tree-sitter-cli.lua
@@ -62,9 +62,7 @@ so we can update the arch mappings accordingly at https://github.com/FourierTran
 
    util.printout("Extracting " .. filename)
    if platform == "windows" then
-      -- Not sure if bug or the tree-sitter gzip file is odd, but this has to not have a filename associated
-      -- otherwise the extraction doesn't work.
-      ok, err = fs.gunzip(filename)
+      ok, err = fs.gunzip(filename, "tree-sitter.exe")
    else
       ok, err = fs.gunzip(filename, "tree-sitter")
    end


### PR DESCRIPTION
This PR fixes #1 by applying the specified patch.