### PR TITLE
Better support for unzipping on Windows

### DIFF
--- a/luarocks-build-tree-sitter-cli-0.0.3-1.rockspec
+++ b/luarocks-build-tree-sitter-cli-0.0.3-1.rockspec
@@ -1,7 +1,7 @@
 rockspec_format = "3.0"
 
 package = "luarocks-build-tree-sitter-cli"
-version = "scm-1"
+version = "0.0.3-1"
 
 description = {
     summary = "A LuaRocks build backend to install the tree-sitter CLI",
@@ -17,5 +17,5 @@ dependencies = {
 
 source = {
     url = "git+https://github.com/FourierTransformer/luarocks-build-tree-sitter-cli",
-    branch = "windows-test"
+    tag = "0.0.3"
 }

--- a/luarocks-build-tree-sitter-cli-scm-1.rockspec
+++ b/luarocks-build-tree-sitter-cli-scm-1.rockspec
@@ -1,7 +1,7 @@
 rockspec_format = "3.0"
 
 package = "luarocks-build-tree-sitter-cli"
-version = "0.0.2-1"
+version = "scm-1"
 
 description = {
     summary = "A LuaRocks build backend to install the tree-sitter CLI",
@@ -17,5 +17,5 @@ dependencies = {
 
 source = {
     url = "git+https://github.com/FourierTransformer/luarocks-build-tree-sitter-cli",
-    tag = "0.0.2"
+    branch = "windows-test"
 }

--- a/src/luarocks/build/tree-sitter-cli.lua
+++ b/src/luarocks/build/tree-sitter-cli.lua
@@ -63,6 +63,11 @@ so we can update the arch mappings accordingly at https://github.com/FourierTran
    util.printout("Extracting " .. filename)
    if platform == "windows" then
       ok, err = fs.gunzip(filename, "tree-sitter.exe")
+
+      -- sometimes the above works, sometimes it doesn't. This should allow both!
+      if not ok then
+         ok, err = fs.gunzip(filename)
+      end
    else
       ok, err = fs.gunzip(filename, "tree-sitter")
    end

--- a/src/luarocks/build/tree-sitter-cli.lua
+++ b/src/luarocks/build/tree-sitter-cli.lua
@@ -62,9 +62,7 @@ so we can update the arch mappings accordingly at https://github.com/FourierTran
 
    util.printout("Extracting " .. filename)
    if platform == "windows" then
-      -- Not sure if bug or the tree-sitter gzip file is odd, but this has to not have a filename associated
-      -- otherwise the extraction doesn't work.
-      ok, err = fs.gunzip(filename)
+      ok, err = fs.gunzip(filename, "tree-sitter.exe")
    else
       ok, err = fs.gunzip(filename, "tree-sitter")
    end


### PR DESCRIPTION
Not entirely sure why, but some Windows installs fail with:

```lua
ok, err = fs.gunzip(filename, "tree-sitter.exe")
```

and some fail with:
```lua
ok, err = fs.gunzip(filename)
```

So, just going to do both and hope the file gets extracted properly!